### PR TITLE
Remove mention of Audacity on auto recovery

### DIFF
--- a/src/AutoRecoveryDialog.cpp
+++ b/src/AutoRecoveryDialog.cpp
@@ -122,7 +122,7 @@ void AutoRecoveryDialog::PopulateOrExchange(ShuttleGui &S)
 
       S.StartHorizontalLay(wxALIGN_CENTRE, 0);
       {
-         S.Id(ID_QUIT_AUDACITY).AddButton(XXO("&Quit Audacity"));
+         S.Id(ID_QUIT_AUDACITY).AddButton(XXO("&Quit Audacium"));
          S.Id(ID_DISCARD_SELECTED).AddButton(XXO("&Discard Selected"));
          S.Id(ID_RECOVER_SELECTED).AddButton(XXO("&Recover Selected"), wxALIGN_CENTRE, true);
          S.Id(ID_SKIP).AddButton(XXO("&Skip"));


### PR DESCRIPTION
Audacity was still mentioned on the quit button on the auto recovery dialogue.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I made sure the code compiles on my machine.
- [x] I made sure there are no unnecessary changes in the code.
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving.
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?".
- [x] I hereby reaffirm that I am licensing my contribution under the GNU General Public License v2.0 or later (`GPL-2.0-or-later`).
