### PR TITLE
Add new colors for WaveColor

### DIFF
--- a/src/AllThemeResources.h
+++ b/src/AllThemeResources.h
@@ -44,8 +44,7 @@ from there.  Audacity will look for a file called "Pause.png".
 // Note: No '#ifndef/#define' pair on this header file.
 // we want to include it multiple times in Theme.cpp.
 
-
-
+#include "Experimental.cmake"
 
 #include "MacroMagic.h"
 #define XPMS_RETIRED
@@ -229,11 +228,16 @@ from there.  Audacity will look for a file called "Pause.png".
    DEFINE_IMAGE( bmpBottomFrequencyCursor, wxImage( 32, 32 ), wxT("BottomFrequencyCursor"));
    DEFINE_IMAGE( bmpTopFrequencyCursor, wxImage( 32, 32 ), wxT("TopFrequencyCursor"));
    DEFINE_IMAGE( bmpBandWidthCursor, wxImage(32, 32), wxT("BandWidthCursor"));
-   DEFINE_IMAGE( bmpSubViewsCursor, wxImage(32, 32), wxT("SubViewsCursor"));
 
    //SET_THEME_FLAGS(  resFlagNewLine  );
 
+// DA: The logo with name xpm has a different width.
+#ifdef EXPERIMENTAL_DA
+#define LOGOWITHNAME_WIDTH 629
+#else
 #define LOGOWITHNAME_WIDTH 506
+#endif
+
 #define LOGOWITHNAME_HEIGHT 200
 
    SET_THEME_FLAGS( resFlagNewLine );
@@ -365,3 +369,27 @@ from there.  Audacity will look for a file called "Pause.png".
    DEFINE_COLOUR( clrSpectro4Sel,         wxColour(  191,    0,    0),  wxT("Spectro4Sel") );
    DEFINE_COLOUR( clrSpectro5Sel,         wxColour(  191,  191,  191),  wxT("Spectro5Sel") );
 
+   DEFINE_COLOUR( clrInstrument1,         wxColour(    64,    0,  255),  wxT("Blue-violet") );
+   DEFINE_COLOUR( clrInstrument2,         wxColour(   128,    0,  255),  wxT("Violet") );
+   DEFINE_COLOUR( clrInstrument3,         wxColour(   191,    0,  255),  wxT("Red-violet") );
+   DEFINE_COLOUR( clrInstrument4,         wxColour(   255,    0,  255),  wxT("Purple") );
+   DEFINE_COLOUR( clrInstrument5,         wxColour(   255,    0,  191),  wxT("Fuschia") );
+   DEFINE_COLOUR( clrInstrument6,         wxColour(   255,    0,  128),  wxT("Magenta") );
+   DEFINE_COLOUR( clrInstrument7,         wxColour(   255,    0,   64),  wxT("Blue-red") );
+   DEFINE_COLOUR( clrInstrument8,         wxColour(   255,    0,    0),  wxT("Red") );
+   DEFINE_COLOUR( clrInstrument9,         wxColour(   255,   64,    0),  wxT("Orange-red") );
+   DEFINE_COLOUR( clrInstrument10,        wxColour(   255,  128,    0),  wxT("Orange") );
+   DEFINE_COLOUR( clrInstrument11,        wxColour(   255,  191,    0),  wxT("Orange-yellow") );
+   DEFINE_COLOUR( clrInstrument12,        wxColour(   255,  255,    0),  wxT("Yellow") );
+   DEFINE_COLOUR( clrInstrument13,        wxColour(   191,  255,    0),  wxT("Chartreuse") );
+   DEFINE_COLOUR( clrInstrument14,        wxColour(   128,  255,    0),  wxT("Yellow-green") );
+   DEFINE_COLOUR( clrInstrument15,        wxColour(    64,  255,    0),  wxT("Spring-green") );
+   DEFINE_COLOUR( clrInstrument16,        wxColour(     0,  255,    0),  wxT("Green") );
+   DEFINE_COLOUR( clrInstrument17,        wxColour(     0,  255,   64),  wxT("Blue-green") );
+   DEFINE_COLOUR( clrInstrument18,        wxColour(     0,  255,  128),  wxT("Agua Green") );
+   DEFINE_COLOUR( clrInstrument19,        wxColour(     0,  255,  191),  wxT("Aqua Blue") );
+   DEFINE_COLOUR( clrInstrument20,        wxColour(     0,  255,  255),  wxT("Cyan") );
+   DEFINE_COLOUR( clrInstrument21,        wxColour(     0,  191,  255),  wxT("Turquoise") );
+   DEFINE_COLOUR( clrInstrument22,        wxColour(     0,  128,  255),  wxT("Cerulean Blue") );
+   DEFINE_COLOUR( clrInstrument23,        wxColour(     0,   64,  255),  wxT("Deep Sky Blue") );
+   DEFINE_COLOUR( clrInstrument24,        wxColour(     0,    0,  255),  wxT("Blue") );

--- a/src/AllThemeResources.h
+++ b/src/AllThemeResources.h
@@ -234,8 +234,6 @@ from there.  Audacity will look for a file called "Pause.png".
 
 // DA: The logo with name xpm has a different width.
 #define LOGOWITHNAME_WIDTH 506
-#endif
-
 #define LOGOWITHNAME_HEIGHT 200
 
    SET_THEME_FLAGS( resFlagNewLine );

--- a/src/AllThemeResources.h
+++ b/src/AllThemeResources.h
@@ -233,8 +233,6 @@ from there.  Audacity will look for a file called "Pause.png".
    //SET_THEME_FLAGS(  resFlagNewLine  );
 
 // DA: The logo with name xpm has a different width.
-#define LOGOWITHNAME_WIDTH 629
-#else
 #define LOGOWITHNAME_WIDTH 506
 #endif
 

--- a/src/AllThemeResources.h
+++ b/src/AllThemeResources.h
@@ -228,11 +228,11 @@ from there.  Audacity will look for a file called "Pause.png".
    DEFINE_IMAGE( bmpBottomFrequencyCursor, wxImage( 32, 32 ), wxT("BottomFrequencyCursor"));
    DEFINE_IMAGE( bmpTopFrequencyCursor, wxImage( 32, 32 ), wxT("TopFrequencyCursor"));
    DEFINE_IMAGE( bmpBandWidthCursor, wxImage(32, 32), wxT("BandWidthCursor"));
+   DEFINE_IMAGE( bmpSubViewsCursor, wxImage(32, 32), wxT("SubViewsCursor"));
 
    //SET_THEME_FLAGS(  resFlagNewLine  );
 
 // DA: The logo with name xpm has a different width.
-#ifdef EXPERIMENTAL_DA
 #define LOGOWITHNAME_WIDTH 629
 #else
 #define LOGOWITHNAME_WIDTH 506

--- a/src/TrackArtist.cpp
+++ b/src/TrackArtist.cpp
@@ -38,15 +38,14 @@ audio tracks.
 
 *//*******************************************************************/
 
-
+#include "Audacity.h" // for USE_* macros and HAVE_ALLOCA_H
 #include "TrackArtist.h"
 
-
+#include "Experimental.h"
 
 #include "AColor.h"
 #include "AllThemeResources.h"
 #include "prefs/GUIPrefs.h"
-#include "Theme.h"
 #include "Track.h"
 #include "TrackPanelDrawingContext.h"
 #include "ViewInfo.h"
@@ -101,26 +100,109 @@ void TrackArtist::SetColours( int iColorIndex)
    theTheme.SetPenColour(   selsamplePen,    clrSelSample);
    theTheme.SetPenColour(   muteRmsPen,      clrMuteRms);
 
-   switch( iColorIndex %4 )
+   switch( iColorIndex %25 ) // InstrumentIDs
    {
       default:
       case 0:
          theTheme.SetPenColour(   samplePen,       clrSample);
          theTheme.SetPenColour(   rmsPen,          clrRms);
          break;
-      case 1: // RED
-         samplePen.SetColour( wxColor( 160,10,10 ) );
-         rmsPen.SetColour( wxColor( 230,80,80 ) );
+      case 1: // Blue-violet
+         theTheme.SetPenColour(    samplePen,       clrInstrument1);
+         rmsPen.SetColour(wxColor(AColor::Blend( theTheme.Colour( clrInstrument1 ), wxColour(255,255,255))));
          break;
-      case 2: // GREEN
-         samplePen.SetColour( wxColor( 35,110,35 ) );
-         rmsPen.SetColour( wxColor( 75,200,75 ) );
+      case 2: // Violet
+         theTheme.SetPenColour(    samplePen,       clrInstrument2);
+         rmsPen.SetColour(wxColor(AColor::Blend( theTheme.Colour( clrInstrument2 ), wxColour(255,255,255))));
          break;
-      case 3: //BLACK
-         samplePen.SetColour( wxColor( 0,0,0 ) );
-         rmsPen.SetColour( wxColor( 100,100,100 ) );
+      case 3: // Red-violet
+         theTheme.SetPenColour(    samplePen,       clrInstrument3);
+         rmsPen.SetColour(wxColor(AColor::Blend( theTheme.Colour( clrInstrument3 ), wxColour(255,255,255))));
          break;
-
+      case 4: // Purple
+         theTheme.SetPenColour(    samplePen,       clrInstrument4);
+         rmsPen.SetColour(wxColor(AColor::Blend( theTheme.Colour( clrInstrument4 ), wxColour(255,255,255))));
+         break;
+      case 5: // Fuschia
+         theTheme.SetPenColour(    samplePen,       clrInstrument5);
+         rmsPen.SetColour(wxColor(AColor::Blend( theTheme.Colour( clrInstrument5 ), wxColour(255,255,255))));
+         break;
+      case 6: // Magenta
+         theTheme.SetPenColour(    samplePen,       clrInstrument6);
+         rmsPen.SetColour(wxColor(AColor::Blend( theTheme.Colour( clrInstrument6 ), wxColour(255,255,255))));
+         break;
+      case 7: // Blue-red
+         theTheme.SetPenColour(    samplePen,       clrInstrument7);
+         rmsPen.SetColour(wxColor(AColor::Blend( theTheme.Colour( clrInstrument7 ), wxColour(255,255,255))));
+         break;
+      case 8: // Red
+         theTheme.SetPenColour(    samplePen,       clrInstrument8);
+         rmsPen.SetColour(wxColor(AColor::Blend( theTheme.Colour( clrInstrument8 ), wxColour(255,255,255))));
+         break;
+      case 9: // Orange-red
+         theTheme.SetPenColour(    samplePen,       clrInstrument9);
+         rmsPen.SetColour(wxColor(AColor::Blend( theTheme.Colour( clrInstrument9 ), wxColour(255,255,255))));
+         break;
+      case 10: // Orange
+         theTheme.SetPenColour(    samplePen,       clrInstrument10);
+         rmsPen.SetColour(wxColor(AColor::Blend( theTheme.Colour( clrInstrument10 ), wxColour(255,255,255))));
+         break;
+      case 11: // Orange-yellow
+         theTheme.SetPenColour(    samplePen,       clrInstrument11);
+         rmsPen.SetColour(wxColor(AColor::Blend( theTheme.Colour( clrInstrument11 ), wxColour(255,255,255))));
+         break;
+      case 12: // Yellow
+         theTheme.SetPenColour(    samplePen,       clrInstrument12);
+         rmsPen.SetColour(wxColor(AColor::Blend( theTheme.Colour( clrInstrument12 ), wxColour(255,255,255))));
+         break;
+      case 13: // Chartreuse
+         theTheme.SetPenColour(    samplePen,       clrInstrument13);
+         rmsPen.SetColour(wxColor(AColor::Blend( theTheme.Colour( clrInstrument13 ), wxColour(255,255,255))));
+         break;
+      case 14: // Yellow-green
+         theTheme.SetPenColour(    samplePen,       clrInstrument14);
+         rmsPen.SetColour(wxColor(AColor::Blend( theTheme.Colour( clrInstrument14 ), wxColour(255,255,255))));
+         break;
+      case 15: // Spring-green
+         theTheme.SetPenColour(    samplePen,       clrInstrument15);
+         rmsPen.SetColour(wxColor(AColor::Blend( theTheme.Colour( clrInstrument15 ), wxColour(255,255,255))));
+         break;
+      case 16: // Green
+         theTheme.SetPenColour(    samplePen,       clrInstrument16);
+         rmsPen.SetColour(wxColor(AColor::Blend( theTheme.Colour( clrInstrument16 ), wxColour(255,255,255))));
+         break;
+      case 17: // Blue-green
+         theTheme.SetPenColour(    samplePen,       clrInstrument17);
+         rmsPen.SetColour(wxColor(AColor::Blend( theTheme.Colour( clrInstrument17 ), wxColour(255,255,255))));
+         break;
+      case 18: // Agua Green
+         theTheme.SetPenColour(    samplePen,       clrInstrument18);
+         rmsPen.SetColour(wxColor(AColor::Blend( theTheme.Colour( clrInstrument18 ), wxColour(255,255,255))));
+         break;
+      case 19: // Aqua Blue
+         theTheme.SetPenColour(    samplePen,       clrInstrument19);
+         rmsPen.SetColour(wxColor(AColor::Blend( theTheme.Colour( clrInstrument19 ), wxColour(255,255,255))));
+         break;
+      case 20: // Cyan
+         theTheme.SetPenColour(    samplePen,       clrInstrument20);
+         rmsPen.SetColour(wxColor(AColor::Blend( theTheme.Colour( clrInstrument20 ), wxColour(255,255,255))));
+         break;
+      case 21: // Turquoise
+         theTheme.SetPenColour(    samplePen,       clrInstrument21);
+         rmsPen.SetColour(wxColor(AColor::Blend( theTheme.Colour( clrInstrument21 ), wxColour(255,255,255))));
+         break;
+      case 22: // Cerulean Blue
+         theTheme.SetPenColour(    samplePen,       clrInstrument22);
+         rmsPen.SetColour(wxColor(AColor::Blend( theTheme.Colour( clrInstrument22 ), wxColour(255,255,255))));
+         break;
+      case 23: // Deep Sky Blue
+         theTheme.SetPenColour(    samplePen,       clrInstrument23);
+         rmsPen.SetColour(wxColor(AColor::Blend( theTheme.Colour( clrInstrument23 ), wxColour(255,255,255))));
+         break;
+      case 24: // Blue
+         theTheme.SetPenColour(    samplePen,       clrInstrument24);
+         rmsPen.SetColour(wxColor(AColor::Blend( theTheme.Colour( clrInstrument24 ), wxColour(255,255,255))));
+         break;
    }
 }
 
@@ -237,6 +319,13 @@ void TrackArt::DrawNegativeOffsetTrackArrows(
 }
 
 
+#ifdef __GNUC__
+#define CONST
+#else
+#define CONST const
+#endif
+
+
 #ifdef USE_MIDI
 #endif // USE_MIDI
 
@@ -245,8 +334,6 @@ void TrackArtist::UpdateSelectedPrefs( int id )
 {
    if( id == ShowClippingPrefsID())
       mShowClipping = gPrefs->Read(wxT("/GUI/ShowClipping"), mShowClipping);
-   if( id == ShowTrackNameInWaveformPrefsID())
-      mbShowTrackNameInTrack = gPrefs->ReadBool(wxT("/GUI/ShowTrackNameInWaveform"), false);
 }
 
 void TrackArtist::UpdatePrefs()
@@ -254,8 +341,10 @@ void TrackArtist::UpdatePrefs()
    mdBrange = gPrefs->Read(ENV_DB_KEY, mdBrange);
    mSampleDisplay = TracksPrefs::SampleViewChoice();
 
+   mbShowTrackNameInTrack =
+      gPrefs->ReadBool(wxT("/GUI/ShowTrackNameInWaveform"), false);
+
    UpdateSelectedPrefs( ShowClippingPrefsID() );
-   UpdateSelectedPrefs( ShowTrackNameInWaveformPrefsID() );
 
    SetColours(0);
 }
@@ -266,7 +355,7 @@ void TrackArtist::UpdatePrefs()
 // two steps down for every one across. This creates a pattern that repeats in
 // 5-step by 5-step boxes. Because we're only drawing in 5/25 possible positions
 // we have a grid spacing somewhat smaller than the image dimensions. Thus we
-// achieve lower density than with a square grid and eliminate edge cases where
+// acheive lower density than with a square grid and eliminate edge cases where
 // no tiles are displayed.
 //
 // The pattern draws in tiles at (0,0), (2,1), (4,2), (1,3), and (3,4) in each
@@ -400,7 +489,7 @@ void TrackArt::DrawBackgroundWithSelection(
    dc->SetPen(*wxTRANSPARENT_PEN);
    if (track->GetSelected() || track->IsSyncLockSelected())
    {
-      // Rectangles before, within, after the selection
+      // Rectangles before, within, after the selction
       wxRect before = rect;
       wxRect within = rect;
       wxRect after = rect;
@@ -420,13 +509,6 @@ void TrackArt::DrawBackgroundWithSelection(
 
       if (within.GetRight() > rect.GetRight()) {
          within.width = 1 + rect.GetRight() - within.x;
-      }
-
-      // Bug 2389 - Selection can disappear
-      // This handles case where no waveform is visible.
-      if (within.width < 1)
-      {
-         within.width = 1;
       }
 
       if (within.width > 0) {
@@ -461,4 +543,3 @@ void TrackArt::DrawBackgroundWithSelection(
       dc->DrawRectangle(rect);
    }
 }
-

--- a/src/TrackArtist.cpp
+++ b/src/TrackArtist.cpp
@@ -41,7 +41,7 @@ audio tracks.
 #include "Audacity.h" // for USE_* macros and HAVE_ALLOCA_H
 #include "TrackArtist.h"
 
-#include "Experimental.h"
+#include "Experimental.cmake"
 
 #include "AColor.h"
 #include "AllThemeResources.h"

--- a/src/TrackArtist.cpp
+++ b/src/TrackArtist.cpp
@@ -355,7 +355,7 @@ void TrackArtist::UpdatePrefs()
 // two steps down for every one across. This creates a pattern that repeats in
 // 5-step by 5-step boxes. Because we're only drawing in 5/25 possible positions
 // we have a grid spacing somewhat smaller than the image dimensions. Thus we
-// acheive lower density than with a square grid and eliminate edge cases where
+// achieve lower density than with a square grid and eliminate edge cases where
 // no tiles are displayed.
 //
 // The pattern draws in tiles at (0,0), (2,1), (4,2), (1,3), and (3,4) in each
@@ -489,7 +489,7 @@ void TrackArt::DrawBackgroundWithSelection(
    dc->SetPen(*wxTRANSPARENT_PEN);
    if (track->GetSelected() || track->IsSyncLockSelected())
    {
-      // Rectangles before, within, after the selction
+      // Rectangles before, within, after the selection
       wxRect before = rect;
       wxRect within = rect;
       wxRect after = rect;


### PR DESCRIPTION
This Audacity fork needs a facelift in order to stand out (in my opinion). And what better way to do so than improving the current wave color system? Four colors is probably good enough for the basic to mid level user. For advanced users with large numbers of tracks, this isn't good enough.
So this commit adds 20 colors to Wave Color selection.
There are 2 file patches: AllThemeResources.h and TrackArtist.cpp.

- [x] I made sure the code compiles on my machine.
- [x] I made sure there are no unnecessary changes in the code.
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving.
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?".
- [x] I hereby reaffirm that I am licensing my contribution under the GNU General Public License v2.0 or later (`GPL-2.0-or-later`).
