### PR TITLE
Updated 'Audacity' to 'Audacium' in Comments

### DIFF
--- a/src/ActiveProjects.h
+++ b/src/ActiveProjects.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Audacium: A Digital Audio Editor
 
   ActiveProjects.h
 

--- a/src/AdornedRulerPanel.cpp
+++ b/src/AdornedRulerPanel.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Audacium: A Digital Audio Editor
 
   AdornedRulerPanel.cpp
 

--- a/src/AdornedRulerPanel.h
+++ b/src/AdornedRulerPanel.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Audacium: A Digital Audio Editor
 
   AdornedRulerPanel.h
 

--- a/src/AllThemeResources.cpp
+++ b/src/AllThemeResources.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
  
- Audacity: A Digital Audio Editor
+ Audacium: A Digital Audio Editor
  
  AllThemeResources.cpp
  

--- a/src/AllThemeResources.h
+++ b/src/AllThemeResources.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Audacium: A Digital Audio Editor
 
   AllThemeResources.h
 

--- a/src/AttachedVirtualFunction.h
+++ b/src/AttachedVirtualFunction.h
@@ -1,6 +1,6 @@
 /*!********************************************************************
 
-Audacity: A Digital Audio Editor
+Audacium: A Digital Audio Editor
 
 @file AttachedVirtualFunction.h
 @brief Utility for non-intrusive definition of a new method on a base class

--- a/src/AudacityApp.cpp
+++ b/src/AudacityApp.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Audacium: A Digital Audio Editor
 
   AudacityApp.cpp
 

--- a/src/AudacityApp.h
+++ b/src/AudacityApp.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Audacium: A Digital Audio Editor
 
   AudacityApp.h
 

--- a/src/AudacityException.cpp
+++ b/src/AudacityException.cpp
@@ -1,6 +1,6 @@
 /*!********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Audacium: A Digital Audio Editor
 
   @file AudacityException.cpp
   @brief Implements AudacityException and related

--- a/src/AudacityException.h
+++ b/src/AudacityException.h
@@ -3,7 +3,7 @@
 
 /*!********************************************************************
 
- Audacity: A Digital Audio Editor
+ Audacium: A Digital Audio Editor
 
  @file AudacityException.h
  @brief Declare abstract class AudacityException, some often-used subclasses, and @ref GuardedCall

--- a/src/AudacityFileConfig.cpp
+++ b/src/AudacityFileConfig.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-Audacity: A Digital Audio Editor
+Audacium: A Digital Audio Editor
 
 AudacityFileConfig.cpp
 

--- a/src/AudacityFileConfig.h
+++ b/src/AudacityFileConfig.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-Audacity: A Digital Audio Editor
+Audacium: A Digital Audio Editor
 
 @file AudacityFileConfig.h
 @brief Extend FileConfig with application-specific behavior

--- a/src/AudacityHeaders.cpp
+++ b/src/AudacityHeaders.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Audacium: A Digital Audio Editor
 
   AudacityHeaders.cpp
 

--- a/src/AudacityHeaders.h
+++ b/src/AudacityHeaders.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Audacium: A Digital Audio Editor
 
   AudacityHeaders.h
 

--- a/src/AudacityLogger.cpp
+++ b/src/AudacityLogger.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Audacium: A Digital Audio Editor
 
   AudacityLogger.cpp
 

--- a/src/AudacityLogger.h
+++ b/src/AudacityLogger.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Audacium: A Digital Audio Editor
 
   AudacityLogger.h
 

--- a/src/AudioIO.cpp
+++ b/src/AudioIO.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Audacium: A Digital Audio Editor
 
   AudioIO.cpp
 

--- a/src/AudioIO.h
+++ b/src/AudioIO.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Audacium: A Digital Audio Editor
 
   AudioIO.h
 

--- a/src/AudioIOBase.cpp
+++ b/src/AudioIOBase.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-Audacity: A Digital Audio Editor
+Audacium: A Digital Audio Editor
 
 AudioIOBase.cpp
 

--- a/src/AudioIOBase.h
+++ b/src/AudioIOBase.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-Audacity: A Digital Audio Editor
+Audacium: A Digital Audio Editor
 
 AudioIOBase.h
 

--- a/src/AudioIOListener.h
+++ b/src/AudioIOListener.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Audacium: A Digital Audio Editor
 
   AudioIOListener.h
 

--- a/src/AutoRecoveryDialog.cpp
+++ b/src/AutoRecoveryDialog.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-Audacity: A Digital Audio Editor
+Audacium: A Digital Audio Editor
 
 AutoRecoveryDialog.cpp
 

--- a/src/AutoRecoveryDialog.h
+++ b/src/AutoRecoveryDialog.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-Audacity: A Digital Audio Editor
+Audacium: A Digital Audio Editor
 
 AutoRecoveryDialog.h
 

--- a/src/BatchCommandDialog.cpp
+++ b/src/BatchCommandDialog.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Audacium: A Digital Audio Editor
 
   BatchCommandDialog.cpp
 

--- a/src/BatchCommandDialog.h
+++ b/src/BatchCommandDialog.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Audacium: A Digital Audio Editor
 
   BatchCommandDialog.h
 

--- a/src/BatchCommands.cpp
+++ b/src/BatchCommands.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Audacium: A Digital Audio Editor
 
   MacroCommands.cpp
 

--- a/src/BatchCommands.h
+++ b/src/BatchCommands.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Audacium: A Digital Audio Editor
 
   MacroCommands.h
 

--- a/src/BatchProcessDialog.cpp
+++ b/src/BatchProcessDialog.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Audacium: A Digital Audio Editor
 
   ApplyMacroDialog.cpp
 

--- a/src/BatchProcessDialog.h
+++ b/src/BatchProcessDialog.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Audacium: A Digital Audio Editor
 
   BatchProcessDialog.h
 

--- a/src/Benchmark.cpp
+++ b/src/Benchmark.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Audacium: A Digital Audio Editor
 
   Benchmark.cpp
 

--- a/src/Benchmark.h
+++ b/src/Benchmark.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Audacium: A Digital Audio Editor
 
   Benchmark.h
 

--- a/src/CellularPanel.cpp
+++ b/src/CellularPanel.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Audacium: A Digital Audio Editor
 
   CellularPanel.cpp
 

--- a/src/CellularPanel.h
+++ b/src/CellularPanel.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
- Audacity: A Digital Audio Editor
+ Audacium: A Digital Audio Editor
 
  CellularPanel.h
 

--- a/src/ClientData.h
+++ b/src/ClientData.h
@@ -1,6 +1,6 @@
 /*!********************************************************************
 
-Audacity: A Digital Audio Editor
+Audacium: A Digital Audio Editor
 
 @file ClientData.h
 @brief Utility ClientData::Site to register hooks into a host class that attach client data

--- a/src/ClientDataHelpers.h
+++ b/src/ClientDataHelpers.h
@@ -1,6 +1,6 @@
 /*!********************************************************************
 
-Audacity: A Digital Audio Editor
+Audacium: A Digital Audio Editor
 
 @file ClientDataHelpers.h
 @brief Some implementation details for ClientData

--- a/src/Clipboard.cpp
+++ b/src/Clipboard.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Audacium: A Digital Audio Editor
 
   Clipboard.cpp
 

--- a/src/Clipboard.h
+++ b/src/Clipboard.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Audacium: A Digital Audio Editor
 
   Clipboard.h
 

--- a/src/CommonCommandFlags.cpp
+++ b/src/CommonCommandFlags.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-Audacity: A Digital Audio Editor
+Audacium: A Digital Audio Editor
 
 CommonCommandFlags.cpp
 

--- a/src/CommonCommandFlags.h
+++ b/src/CommonCommandFlags.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-Audacity: A Digital Audio Editor
+Audacium: A Digital Audio Editor
 
 CommonCommandFlags.h
 

--- a/src/CrossFade.cpp
+++ b/src/CrossFade.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Audacium: A Digital Audio Editor
 
   CrossFade.cpp
 

--- a/src/CrossFade.h
+++ b/src/CrossFade.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Audacium: A Digital Audio Editor
 
   CrossFade.h
 

--- a/src/DBConnection.cpp
+++ b/src/DBConnection.cpp
@@ -1,6 +1,6 @@
 /*!********************************************************************
 
-Audacity: A Digital Audio Editor
+Audacium: A Digital Audio Editor
 
 @file DBConnection.cpp
 @brief Implements DBConnection

--- a/src/DBConnection.h
+++ b/src/DBConnection.h
@@ -1,6 +1,6 @@
 /*!********************************************************************
 
-Audacity: A Digital Audio Editor
+Audacium: A Digital Audio Editor
 
 @file DBConnection.h
 @brief Declare DBConnection, which maintains database connection and associated status and background thread

--- a/src/Dependencies.cpp
+++ b/src/Dependencies.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-   Audacity: A Digital Audio Editor
+   Audacium: A Digital Audio Editor
    Audacity(R) is copyright (c) 1999-2008 Audacity Team.
    License: GPL v2.  See License.txt.
 

--- a/src/Dependencies.h
+++ b/src/Dependencies.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-   Audacity: A Digital Audio Editor
+   Audacium: A Digital Audio Editor
    Audacity(R) is copyright (c) 1999-2008 Audacity Team.
    License: GPL v2.  See License.txt.
 

--- a/src/DeviceChange.cpp
+++ b/src/DeviceChange.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Audacium: A Digital Audio Editor
 
   DeviceChange.cpp
 

--- a/src/DeviceChange.h
+++ b/src/DeviceChange.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Audacium: A Digital Audio Editor
 
   DeviceChange.h
 

--- a/src/DeviceManager.h
+++ b/src/DeviceManager.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Audacium: A Digital Audio Editor
 
   DeviceManager.h
 

--- a/src/Diags.cpp
+++ b/src/Diags.cpp
@@ -1,7 +1,7 @@
 
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Audacium: A Digital Audio Editor
 
   Diags.cpp
 

--- a/src/Diags.h
+++ b/src/Diags.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Audacium: A Digital Audio Editor
 
   Diags.h
 

--- a/src/Dither.cpp
+++ b/src/Dither.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Audacium: A Digital Audio Editor
 
   Dither.cpp
 

--- a/src/Dither.h
+++ b/src/Dither.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Audacium: A Digital Audio Editor
 
   Steve Harris
   Markus Meyer

--- a/src/Envelope.cpp
+++ b/src/Envelope.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Audacium: A Digital Audio Editor
 
   Envelope.cpp
 

--- a/src/Envelope.h
+++ b/src/Envelope.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Audacium: A Digital Audio Editor
 
   Envelope.h
 

--- a/src/EnvelopeEditor.cpp
+++ b/src/EnvelopeEditor.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Audacium: A Digital Audio Editor
 
   EnvelopeEditor.cpp
 

--- a/src/EnvelopeEditor.h
+++ b/src/EnvelopeEditor.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Audacium: A Digital Audio Editor
 
   EnvelopeEditor.h
 

--- a/src/FFmpeg.cpp
+++ b/src/FFmpeg.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-Audacity: A Digital Audio Editor
+Audacium: A Digital Audio Editor
 
 FFmpeg.cpp
 

--- a/src/FFmpeg.h
+++ b/src/FFmpeg.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-Audacity: A Digital Audio Editor
+Audacium: A Digital Audio Editor
 
 FFmpeg.h
 

--- a/src/FileFormats.cpp
+++ b/src/FileFormats.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Audacium: A Digital Audio Editor
 
   FileFormats.cpp
 

--- a/src/FileFormats.h
+++ b/src/FileFormats.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Audacium: A Digital Audio Editor
 
   FileFormats.h
 

--- a/src/FileIO.cpp
+++ b/src/FileIO.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Audacium: A Digital Audio Editor
 
   FileIO.cpp
 

--- a/src/FileIO.h
+++ b/src/FileIO.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Audacium: A Digital Audio Editor
 
   FileIO.h
 

--- a/src/FileNames.cpp
+++ b/src/FileNames.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Audacium: A Digital Audio Editor
 
   FileNames.cpp
 

--- a/src/FileNames.h
+++ b/src/FileNames.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Audacium: A Digital Audio Editor
 
   FileNames.h
 

--- a/src/FreqWindow.cpp
+++ b/src/FreqWindow.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Audacium: A Digital Audio Editor
 
   FreqWindow.cpp
 

--- a/src/FreqWindow.h
+++ b/src/FreqWindow.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Audacium: A Digital Audio Editor
 
   FreqWindow.h
 

--- a/src/HelpText.cpp
+++ b/src/HelpText.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Audacium: A Digital Audio Editor
 
   HelpText.cpp
 

--- a/src/HelpText.h
+++ b/src/HelpText.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Audacium: A Digital Audio Editor
 
   HelpText.h
 

--- a/src/HistoryWindow.cpp
+++ b/src/HistoryWindow.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Audacium: A Digital Audio Editor
 
   HistoryWindow.cpp
 

--- a/src/HistoryWindow.h
+++ b/src/HistoryWindow.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Audacium: A Digital Audio Editor
 
   HistoryWindow.h
 

--- a/src/HitTestResult.h
+++ b/src/HitTestResult.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-Audacity: A Digital Audio Editor
+Audacium: A Digital Audio Editor
 
 HitTestResult.h
 

--- a/src/ImageManipulation.cpp
+++ b/src/ImageManipulation.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Audacium: A Digital Audio Editor
 
   ImageManipulation.cpp
 

--- a/src/ImageManipulation.h
+++ b/src/ImageManipulation.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Audacium: A Digital Audio Editor
 
   ImageManipulation.h
 

--- a/src/InterpolateAudio.cpp
+++ b/src/InterpolateAudio.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Audacium: A Digital Audio Editor
 
   InterpolateAudio.cpp
 

--- a/src/InterpolateAudio.h
+++ b/src/InterpolateAudio.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Audacium: A Digital Audio Editor
 
   InterpolateAudio.h
 

--- a/src/KeyboardCapture.cpp
+++ b/src/KeyboardCapture.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
  
- Audacity: A Digital Audio Editor
+ Audacium: A Digital Audio Editor
  
  KeyboardCapture.cpp
  

--- a/src/KeyboardCapture.h
+++ b/src/KeyboardCapture.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Audacium: A Digital Audio Editor
 
   KeyboardCapture.h
 

--- a/src/LabelDialog.cpp
+++ b/src/LabelDialog.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Audacium: A Digital Audio Editor
 
   LabelDialog.cpp
 

--- a/src/LabelDialog.h
+++ b/src/LabelDialog.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Audacium: A Digital Audio Editor
 
   LabelDialog.h
 

--- a/src/LabelTrack.cpp
+++ b/src/LabelTrack.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Audacium: A Digital Audio Editor
 
   LabelTrack.cpp
 

--- a/src/LabelTrack.h
+++ b/src/LabelTrack.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Audacium: A Digital Audio Editor
 
   LabelTrack.h
 

--- a/src/LangChoice.cpp
+++ b/src/LangChoice.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Audacium: A Digital Audio Editor
 
   LangChoice.cpp
 

--- a/src/LangChoice.h
+++ b/src/LangChoice.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Audacium: A Digital Audio Editor
 
   LangChoice.h
 

--- a/src/Legacy.cpp
+++ b/src/Legacy.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Audacium: A Digital Audio Editor
 
   Legacy.cpp
 

--- a/src/Legacy.h
+++ b/src/Legacy.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Audacium: A Digital Audio Editor
 
   Legacy.h
 

--- a/src/Lyrics.cpp
+++ b/src/Lyrics.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Audacium: A Digital Audio Editor
 
   Lyrics.cpp
 

--- a/src/Lyrics.h
+++ b/src/Lyrics.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Audacium: A Digital Audio Editor
 
   Lyrics.h
 

--- a/src/LyricsWindow.cpp
+++ b/src/LyricsWindow.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Audacium: A Digital Audio Editor
 
   LyricsWindow.cpp
 

--- a/src/LyricsWindow.h
+++ b/src/LyricsWindow.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Audacium: A Digital Audio Editor
 
   LyricsWindow.h
 

--- a/src/MacroMagic.h
+++ b/src/MacroMagic.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Audacium: A Digital Audio Editor
 
   MacroMagic.h
 

--- a/src/Matrix.cpp
+++ b/src/Matrix.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Audacium: A Digital Audio Editor
 
   Matrix.cpp
 

--- a/src/Matrix.h
+++ b/src/Matrix.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Audacium: A Digital Audio Editor
 
   Matrix.h
 

--- a/src/Menus.cpp
+++ b/src/Menus.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Audacium: A Digital Audio Editor
 
   Menus.cpp
 

--- a/src/Menus.h
+++ b/src/Menus.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Audacium: A Digital Audio Editor
 
   Menus.h
 

--- a/src/Mix.cpp
+++ b/src/Mix.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Audacium: A Digital Audio Editor
 
   Mix.cpp
 

--- a/src/Mix.h
+++ b/src/Mix.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Audacium: A Digital Audio Editor
 
   Mix.h
 

--- a/src/MixerBoard.cpp
+++ b/src/MixerBoard.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Audacium: A Digital Audio Editor
 
   MixerBoard.cpp
 

--- a/src/MixerBoard.h
+++ b/src/MixerBoard.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Audacium: A Digital Audio Editor
 
   MixerBoard.h
 

--- a/src/ModuleManager.cpp
+++ b/src/ModuleManager.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Audacium: A Digital Audio Editor
 
   ModuleManager.cpp
 

--- a/src/ModuleManager.h
+++ b/src/ModuleManager.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Audacium: A Digital Audio Editor
 
   ModuleManager.h
 

--- a/src/ModuleSettings.cpp
+++ b/src/ModuleSettings.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Audacium: A Digital Audio Editor
 
   @file ModuleSettings.cpp
 

--- a/src/ModuleSettings.h
+++ b/src/ModuleSettings.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Audacium: A Digital Audio Editor
 
   @file ModuleSettings.h
 

--- a/src/NoteTrack.cpp
+++ b/src/NoteTrack.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Audacium: A Digital Audio Editor
 
   NoteTrack.cpp
 

--- a/src/NoteTrack.h
+++ b/src/NoteTrack.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Audacium: A Digital Audio Editor
 
   NoteTrack.h
 

--- a/src/NumberScale.h
+++ b/src/NumberScale.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-Audacity: A Digital Audio Editor
+Audacium: A Digital Audio Editor
 
 NumberScale.h
 

--- a/src/PitchName.cpp
+++ b/src/PitchName.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-   Audacity: A Digital Audio Editor
+   Audacium: A Digital Audio Editor
    Audacity(R) is copyright (c) 1999-2012 Audacity Team.
    License: GPL v2.  See License.txt.
 

--- a/src/PitchName.h
+++ b/src/PitchName.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-   Audacity: A Digital Audio Editor
+   Audacium: A Digital Audio Editor
    Audacity(R) is copyright (c) 1999-2013 Audacity Team.
    License: GPL v2.  See License.txt.
 

--- a/src/PlatformCompatibility.cpp
+++ b/src/PlatformCompatibility.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Audacium: A Digital Audio Editor
 
   PlatformCompatibility.cpp
 

--- a/src/PlatformCompatibility.h
+++ b/src/PlatformCompatibility.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Audacium: A Digital Audio Editor
 
   PlatformCompatibility.h
 

--- a/src/PlaybackSchedule.cpp
+++ b/src/PlaybackSchedule.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
  
- Audacity: A Digital Audio Editor
+ Audacium: A Digital Audio Editor
  
  PlaybackSchedule.cpp
  

--- a/src/PlaybackSchedule.h
+++ b/src/PlaybackSchedule.h
@@ -1,6 +1,6 @@
 /**********************************************************************
  
- Audacity: A Digital Audio Editor
+ Audacium: A Digital Audio Editor
  
  PlaybackSchedule.h
  

--- a/src/PluginManager.cpp
+++ b/src/PluginManager.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Audacium: A Digital Audio Editor
 
   PluginManager.cpp
 

--- a/src/PluginManager.h
+++ b/src/PluginManager.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Audacium: A Digital Audio Editor
 
   PluginManager.h
 

--- a/src/PluginRegistrationDialog.cpp
+++ b/src/PluginRegistrationDialog.cpp
@@ -1,6 +1,6 @@
 /*!*********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Audacium: A Digital Audio Editor
 
   @file PluginRegistrationDialog.cpp
 

--- a/src/PluginRegistrationDialog.h
+++ b/src/PluginRegistrationDialog.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Audacium: A Digital Audio Editor
 
   PluginRegistrationDialog.h
 

--- a/src/Prefs.cpp
+++ b/src/Prefs.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Audacium: A Digital Audio Editor
 
   Prefs.cpp
 

--- a/src/Prefs.h
+++ b/src/Prefs.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Audacium: A Digital Audio Editor
 
   Prefs.h
 

--- a/src/Printing.cpp
+++ b/src/Printing.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Audacium: A Digital Audio Editor
 
   Printing.cpp
 

--- a/src/Printing.h
+++ b/src/Printing.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Audacium: A Digital Audio Editor
 
   Printing.h
 

--- a/src/Profiler.cpp
+++ b/src/Profiler.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Audacium: A Digital Audio Editor
 
   Profiler.cpp
 

--- a/src/Profiler.h
+++ b/src/Profiler.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Audacium: A Digital Audio Editor
 
   Profiler.h
 

--- a/src/Project.cpp
+++ b/src/Project.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Audacium: A Digital Audio Editor
 
   Project.cpp
 

--- a/src/Project.h
+++ b/src/Project.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Audacium: A Digital Audio Editor
 
   Project.h
 

--- a/src/ProjectAudioIO.cpp
+++ b/src/ProjectAudioIO.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-Audacity: A Digital Audio Editor
+Audacium: A Digital Audio Editor
 
 ProjectAudioIO.cpp
 

--- a/src/ProjectAudioIO.h
+++ b/src/ProjectAudioIO.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-Audacity: A Digital Audio Editor
+Audacium: A Digital Audio Editor
 
 ProjectAudioIO.h
 

--- a/src/ProjectAudioManager.cpp
+++ b/src/ProjectAudioManager.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-Audacity: A Digital Audio Editor
+Audacium: A Digital Audio Editor
 
 ProjectAudioManager.cpp
 

--- a/src/ProjectAudioManager.h
+++ b/src/ProjectAudioManager.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-Audacity: A Digital Audio Editor
+Audacium: A Digital Audio Editor
 
 ProjectAudioManager.h
 

--- a/src/ProjectFSCK.cpp
+++ b/src/ProjectFSCK.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Audacium: A Digital Audio Editor
 
   ProjectFSCK.cpp
 

--- a/src/ProjectFSCK.h
+++ b/src/ProjectFSCK.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Audacium: A Digital Audio Editor
 
   ProjectFSCK.h
 

--- a/src/ProjectFileIO.cpp
+++ b/src/ProjectFileIO.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-Audacity: A Digital Audio Editor
+Audacium: A Digital Audio Editor
 
 ProjectFileIO.cpp
 

--- a/src/ProjectFileIO.h
+++ b/src/ProjectFileIO.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-Audacity: A Digital Audio Editor
+Audacium: A Digital Audio Editor
 
 ProjectFileIO.h
 

--- a/src/ProjectFileIORegistry.cpp
+++ b/src/ProjectFileIORegistry.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Audacium: A Digital Audio Editor
 
   ProjectFileIORegistry.cpp
 

--- a/src/ProjectFileIORegistry.h
+++ b/src/ProjectFileIORegistry.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Audacium: A Digital Audio Editor
 
   ProjectFileIORegistry.h
 

--- a/src/ProjectFileManager.cpp
+++ b/src/ProjectFileManager.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-Audacity: A Digital Audio Editor
+Audacium: A Digital Audio Editor
 
 ProjectFileManager.cpp
 

--- a/src/ProjectFileManager.h
+++ b/src/ProjectFileManager.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-Audacity: A Digital Audio Editor
+Audacium: A Digital Audio Editor
 
 ProjectFileManager.h
 

--- a/src/ProjectHistory.cpp
+++ b/src/ProjectHistory.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-Audacity: A Digital Audio Editor
+Audacium: A Digital Audio Editor
 
 ProjectHistory.cpp
 

--- a/src/ProjectHistory.h
+++ b/src/ProjectHistory.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-Audacity: A Digital Audio Editor
+Audacium: A Digital Audio Editor
 
 ProjectHistory.h
 

--- a/src/ProjectManager.cpp
+++ b/src/ProjectManager.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-Audacity: A Digital Audio Editor
+Audacium: A Digital Audio Editor
 
 ProjectManager.cpp
 

--- a/src/ProjectManager.h
+++ b/src/ProjectManager.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-Audacity: A Digital Audio Editor
+Audacium: A Digital Audio Editor
 
 ProjectManager.h
 

--- a/src/ProjectSelectionManager.cpp
+++ b/src/ProjectSelectionManager.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-Audacity: A Digital Audio Editor
+Audacium: A Digital Audio Editor
 
 ProjectSelectionManager.cpp
 

--- a/src/ProjectSelectionManager.h
+++ b/src/ProjectSelectionManager.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-Audacity: A Digital Audio Editor
+Audacium: A Digital Audio Editor
 
 ProjectSelectionManager.cpp
 

--- a/src/ProjectSerializer.cpp
+++ b/src/ProjectSerializer.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-   Audacity: A Digital Audio Editor
+   Audacium: A Digital Audio Editor
    Audacity(R) is copyright (c) 1999-2010 Audacity Team.
    License: GPL v2.  See License.txt.
 

--- a/src/ProjectSerializer.h
+++ b/src/ProjectSerializer.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-   Audacity: A Digital Audio Editor
+   Audacium: A Digital Audio Editor
    Audacity(R) is copyright (c) 1999-2010 Audacity Team.
    License: GPL v2.  See License.txt.
 

--- a/src/ProjectSettings.cpp
+++ b/src/ProjectSettings.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-Audacity: A Digital Audio Editor
+Audacium: A Digital Audio Editor
 
 ProjectSettings.cpp
 

--- a/src/ProjectSettings.h
+++ b/src/ProjectSettings.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-Audacity: A Digital Audio Editor
+Audacium: A Digital Audio Editor
 
 ProjectSettings.h
 

--- a/src/ProjectStatus.cpp
+++ b/src/ProjectStatus.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-Audacity: A Digital Audio Editor
+Audacium: A Digital Audio Editor
 
 ProjectStatus.h
 

--- a/src/ProjectStatus.h
+++ b/src/ProjectStatus.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-Audacity: A Digital Audio Editor
+Audacium: A Digital Audio Editor
 
 ProjectStatus.h
 

--- a/src/ProjectWindow.cpp
+++ b/src/ProjectWindow.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-Audacity: A Digital Audio Editor
+Audacium: A Digital Audio Editor
 
 ProjectWindow.cpp
 

--- a/src/ProjectWindow.h
+++ b/src/ProjectWindow.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-Audacity: A Digital Audio Editor
+Audacium: A Digital Audio Editor
 
 ProjectWindow.h
 

--- a/src/ProjectWindowBase.cpp
+++ b/src/ProjectWindowBase.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-Audacity: A Digital Audio Editor
+Audacium: A Digital Audio Editor
 
 ProjectWindowBase.cpp
 

--- a/src/ProjectWindowBase.h
+++ b/src/ProjectWindowBase.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-Audacity: A Digital Audio Editor
+Audacium: A Digital Audio Editor
 
 ProjectWindowBase.h
 

--- a/src/RealFFTf48x.cpp
+++ b/src/RealFFTf48x.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-   Audacity: A Digital Audio Editor
+   Audacium: A Digital Audio Editor
 
    RealFFT48x.cpp
 

--- a/src/RefreshCode.h
+++ b/src/RefreshCode.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-Audacity: A Digital Audio Editor
+Audacium: A Digital Audio Editor
 
 RefreshCode.h
 

--- a/src/Registrar.h
+++ b/src/Registrar.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Audacium: A Digital Audio Editor
 
   Registrar.h
 

--- a/src/Registry.cpp
+++ b/src/Registry.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-Audacity: A Digital Audio Editor
+Audacium: A Digital Audio Editor
 
 Registry.cpp
 

--- a/src/Registry.h
+++ b/src/Registry.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-Audacity: A Digital Audio Editor
+Audacium: A Digital Audio Editor
 
 Registry.h
 

--- a/src/Resample.cpp
+++ b/src/Resample.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-   Audacity: A Digital Audio Editor
+   Audacium: A Digital Audio Editor
    Audacity(R) is copyright (c) 1999-2012 Audacity Team.
    License: GPL v2.  See License.txt.
 

--- a/src/Resample.h
+++ b/src/Resample.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-   Audacity: A Digital Audio Editor
+   Audacium: A Digital Audio Editor
    Audacity(R) is copyright (c) 1999-2012 Audacity Team.
    License: GPL v2.  See License.txt.
 

--- a/src/RingBuffer.cpp
+++ b/src/RingBuffer.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Audacium: A Digital Audio Editor
 
   RingBuffer.cpp
 

--- a/src/RingBuffer.h
+++ b/src/RingBuffer.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Audacium: A Digital Audio Editor
 
   RingBuffer.h
 

--- a/src/SampleBlock.cpp
+++ b/src/SampleBlock.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-Audacity: A Digital Audio Editor
+Audacium: A Digital Audio Editor
 
 SampleBlock.cpp
 

--- a/src/SampleBlock.h
+++ b/src/SampleBlock.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-Audacity: A Digital Audio Editor
+Audacium: A Digital Audio Editor
 
 SampleBlock.h
 

--- a/src/SampleFormat.cpp
+++ b/src/SampleFormat.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Audacium: A Digital Audio Editor
 
   SampleFormat.h
 

--- a/src/SampleFormat.h
+++ b/src/SampleFormat.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Audacium: A Digital Audio Editor
 
   @file SampleFormat.h
 

--- a/src/Screenshot.cpp
+++ b/src/Screenshot.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Audacium: A Digital Audio Editor
 
   Screenshot.cpp
 

--- a/src/Screenshot.h
+++ b/src/Screenshot.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Audacium: A Digital Audio Editor
 
   Screenshot.h
 

--- a/src/SelectUtilities.cpp
+++ b/src/SelectUtilities.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
  
- Audacity: A Digital Audio Editor
+ Audacium: A Digital Audio Editor
  
  SelectUtilities.cpp
  

--- a/src/SelectUtilities.h
+++ b/src/SelectUtilities.h
@@ -1,6 +1,6 @@
 /**********************************************************************
  
- Audacity: A Digital Audio Editor
+ Audacium: A Digital Audio Editor
  
  SelectUtilities.h
  

--- a/src/SelectedRegion.cpp
+++ b/src/SelectedRegion.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-Audacity: A Digital Audio Editor
+Audacium: A Digital Audio Editor
 
 SelectedRegion.cpp
 

--- a/src/SelectedRegion.h
+++ b/src/SelectedRegion.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Audacium: A Digital Audio Editor
 
   SelectedRegion.h
 

--- a/src/SelectionState.cpp
+++ b/src/SelectionState.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
- Audacity: A Digital Audio Editor
+ Audacium: A Digital Audio Editor
 
  SelectionState.h
 

--- a/src/SelectionState.h
+++ b/src/SelectionState.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
- Audacity: A Digital Audio Editor
+ Audacium: A Digital Audio Editor
 
  SelectionState.h
 

--- a/src/Sequence.cpp
+++ b/src/Sequence.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Audacium: A Digital Audio Editor
 
   Sequence.cpp
 

--- a/src/Sequence.h
+++ b/src/Sequence.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Audacium: A Digital Audio Editor
 
   Sequence.h
 

--- a/src/Shuttle.h
+++ b/src/Shuttle.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Audacium: A Digital Audio Editor
 
   Shuttle.h
 

--- a/src/ShuttleGetDefinition.cpp
+++ b/src/ShuttleGetDefinition.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Audacium: A Digital Audio Editor
 
   ShuttleGetDefinition.cpp
 

--- a/src/ShuttleGetDefinition.h
+++ b/src/ShuttleGetDefinition.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Audacium: A Digital Audio Editor
 
   ShuttleGetDefinition.h
 

--- a/src/ShuttleGui.cpp
+++ b/src/ShuttleGui.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Audacium: A Digital Audio Editor
 
   ShuttleGui.cpp
 

--- a/src/ShuttleGui.h
+++ b/src/ShuttleGui.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Audacium: A Digital Audio Editor
 
   ShuttleGui.h
 

--- a/src/ShuttlePrefs.cpp
+++ b/src/ShuttlePrefs.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Audacium: A Digital Audio Editor
 
   ShuttlePrefs.cpp
 

--- a/src/ShuttlePrefs.h
+++ b/src/ShuttlePrefs.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Audacium: A Digital Audio Editor
 
   ShuttlePrefs.h
 

--- a/src/Snap.cpp
+++ b/src/Snap.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Audacium: A Digital Audio Editor
 
   Snap.cpp
 

--- a/src/Snap.h
+++ b/src/Snap.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Audacium: A Digital Audio Editor
 
   Snap.h
 

--- a/src/SoundActivatedRecord.cpp
+++ b/src/SoundActivatedRecord.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Audacium: A Digital Audio Editor
 
   SoundActivatedRecord.cpp
 

--- a/src/SoundActivatedRecord.h
+++ b/src/SoundActivatedRecord.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Audacium: A Digital Audio Editor
 
   SoundActivatedRecord.cpp
 

--- a/src/Spectrum.cpp
+++ b/src/Spectrum.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Audacium: A Digital Audio Editor
 
   Spectrum.cpp
 

--- a/src/Spectrum.h
+++ b/src/Spectrum.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Audacium: A Digital Audio Editor
 
   Spectrum.h
 

--- a/src/SpectrumAnalyst.cpp
+++ b/src/SpectrumAnalyst.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Audacium: A Digital Audio Editor
 
   SpectrumAnalyst.cpp
 

--- a/src/SpectrumAnalyst.h
+++ b/src/SpectrumAnalyst.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Audacium: A Digital Audio Editor
 
   SpectrumAnalyst.h
 

--- a/src/SplashDialog.cpp
+++ b/src/SplashDialog.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Audacium: A Digital Audio Editor
 
   SplashDialog.cpp
 

--- a/src/SplashDialog.h
+++ b/src/SplashDialog.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Audacium: A Digital Audio Editor
 
   SplashDialog.h
 

--- a/src/SqliteSampleBlock.cpp
+++ b/src/SqliteSampleBlock.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-Audacity: A Digital Audio Editor
+Audacium: A Digital Audio Editor
 
 SqliteSampleBlock.cpp
 

--- a/src/SseMathFuncs.h
+++ b/src/SseMathFuncs.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-   Audacity: A Digital Audio Editor
+   Audacium: A Digital Audio Editor
 
    SseMathFuncs.h
 

--- a/src/Tags.cpp
+++ b/src/Tags.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Audacium: A Digital Audio Editor
 
   Tags.cpp
 

--- a/src/Tags.h
+++ b/src/Tags.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Audacium: A Digital Audio Editor
 
   Tags.h
 

--- a/src/TempDirectory.cpp
+++ b/src/TempDirectory.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
  
- Audacity: A Digital Audio Editor
+ Audacium: A Digital Audio Editor
  
  TempDirectory.cpp
  

--- a/src/TempDirectory.h
+++ b/src/TempDirectory.h
@@ -1,6 +1,6 @@
 /**********************************************************************
  
- Audacity: A Digital Audio Editor
+ Audacium: A Digital Audio Editor
  
  TempDirectory.h
  

--- a/src/Theme.cpp
+++ b/src/Theme.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Audacium: A Digital Audio Editor
 
   Theme.cpp
 

--- a/src/Theme.h
+++ b/src/Theme.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Audacium: A Digital Audio Editor
 
   Theme.h
 

--- a/src/TimeDialog.cpp
+++ b/src/TimeDialog.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Audacium: A Digital Audio Editor
 
   TimeDialog.cpp
 

--- a/src/TimeDialog.h
+++ b/src/TimeDialog.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Audacium: A Digital Audio Editor
 
   TimeDialog.h
 

--- a/src/TimeTrack.cpp
+++ b/src/TimeTrack.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Audacium: A Digital Audio Editor
 
   TimeTrack.cpp
 

--- a/src/TimeTrack.h
+++ b/src/TimeTrack.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Audacium: A Digital Audio Editor
 
   TimeTrack.h
 

--- a/src/TimerRecordDialog.cpp
+++ b/src/TimerRecordDialog.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Audacium: A Digital Audio Editor
 
   TimerRecordDialog.cpp
 

--- a/src/TimerRecordDialog.h
+++ b/src/TimerRecordDialog.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Audacium: A Digital Audio Editor
 
   TimerRecordDialog.h
 

--- a/src/Track.cpp
+++ b/src/Track.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Audacium: A Digital Audio Editor
 
   Track.cpp
 

--- a/src/Track.h
+++ b/src/Track.h
@@ -1,6 +1,6 @@
 /*!********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Audacium: A Digital Audio Editor
 
   @file Track.h
   @brief declares abstract base class Track, TrackList, and iterators over TrackList

--- a/src/TrackArtist.cpp
+++ b/src/TrackArtist.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Audacium: A Digital Audio Editor
 
   TrackArtist.cpp
 

--- a/src/TrackArtist.h
+++ b/src/TrackArtist.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Audacium: A Digital Audio Editor
 
   TrackArtist.h
 

--- a/src/TrackInfo.cpp
+++ b/src/TrackInfo.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-Audacity: A Digital Audio Editor
+Audacium: A Digital Audio Editor
 
 TrackInfo.cpp
 

--- a/src/TrackInfo.h
+++ b/src/TrackInfo.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-Audacity: A Digital Audio Editor
+Audacium: A Digital Audio Editor
 
 TrackInfo.h
 

--- a/src/TrackPanel.cpp
+++ b/src/TrackPanel.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Audacium: A Digital Audio Editor
 
   TrackPanel.cpp
 

--- a/src/TrackPanel.h
+++ b/src/TrackPanel.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Audacium: A Digital Audio Editor
 
   TrackPanel.h
 

--- a/src/TrackPanelAx.cpp
+++ b/src/TrackPanelAx.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Audacium: A Digital Audio Editor
 
   TrackPanelAx.cpp
 

--- a/src/TrackPanelAx.h
+++ b/src/TrackPanelAx.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Audacium: A Digital Audio Editor
 
   TrackPanelAx.h
 

--- a/src/TrackPanelCell.cpp
+++ b/src/TrackPanelCell.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
  
- Audacity: A Digital Audio Editor
+ Audacium: A Digital Audio Editor
  
  TrackPanelCell.cpp
  

--- a/src/TrackPanelCell.h
+++ b/src/TrackPanelCell.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-Audacity: A Digital Audio Editor
+Audacium: A Digital Audio Editor
 
 TrackPanelCell.h
 

--- a/src/TrackPanelDrawable.cpp
+++ b/src/TrackPanelDrawable.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
  
- Audacity: A Digital Audio Editor
+ Audacium: A Digital Audio Editor
  
  TrackPanelDrawable.cpp
  

--- a/src/TrackPanelDrawable.h
+++ b/src/TrackPanelDrawable.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-Audacity: A Digital Audio Editor
+Audacium: A Digital Audio Editor
 
 TrackPanelDrawable.h
 

--- a/src/TrackPanelDrawingContext.h
+++ b/src/TrackPanelDrawingContext.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
- Audacity: A Digital Audio Editor
+ Audacium: A Digital Audio Editor
 
  TrackPanelDrawingContext.h
 

--- a/src/TrackPanelListener.h
+++ b/src/TrackPanelListener.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Audacium: A Digital Audio Editor
 
   TrackPanelListener.h
 

--- a/src/TrackPanelMouseEvent.h
+++ b/src/TrackPanelMouseEvent.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-Audacity: A Digital Audio Editor
+Audacium: A Digital Audio Editor
 
 TrackPanelMouseEvent.h
 

--- a/src/TrackPanelResizeHandle.cpp
+++ b/src/TrackPanelResizeHandle.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-Audacity: A Digital Audio Editor
+Audacium: A Digital Audio Editor
 
 TrackPanelResizeHandle.cpp
 

--- a/src/TrackPanelResizeHandle.h
+++ b/src/TrackPanelResizeHandle.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-Audacity: A Digital Audio Editor
+Audacium: A Digital Audio Editor
 
 TrackPanelResizeHandle.h
 

--- a/src/TrackPanelResizerCell.cpp
+++ b/src/TrackPanelResizerCell.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-Audacity: A Digital Audio Editor
+Audacium: A Digital Audio Editor
 
 TrackPanelResizeHandle.cpp
 

--- a/src/WaveTrack.cpp
+++ b/src/WaveTrack.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Audacium: A Digital Audio Editor
 
   WaveTrack.cpp
 

--- a/src/WaveTrack.h
+++ b/src/WaveTrack.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Audacium: A Digital Audio Editor
 
   WaveTrack.h
 


### PR DESCRIPTION
Resolves: https://github.com/SartoxOnlyGNU/audacium/issues/9

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I made sure the code compiles on my machine.
- [x] I made sure there are no unnecessary changes in the code.
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving.
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?".
- [x] I hereby reaffirm that I am licensing my contribution under the GNU General Public License v2.0 or later (`GPL-2.0-or-later`).

<br>

The commands used to change the contents in `/src` directory are
1. `sed -i 's/Audacity: A Digital Audio Editor/Audacium: A Digital Audio Editor/g' *.h`
2. `sed -i 's/Audacity: A Digital Audio Editor/Audacium: A Digital Audio Editor/g' *.cpp`.

Credits to the Open source contributor who contributed in [this](https://github.com/tenacityteam/tenacity/commit/44968d3ac316e4a4fd465cb02976fc51699b44fc) commit. Since, I'm not well versed with the `sed` command.
<br>

Also, Check out src/Dependencies.h and src/Dependencies.cpp, for some liscencing as well. Maybe it has to be modified?

Hope you have a great day/night ahead!